### PR TITLE
Improve navigation UI and add multi-bank selector to Question Bank

### DIFF
--- a/404.html
+++ b/404.html
@@ -57,8 +57,10 @@
       left: 0;
       height: 100vh;
       width: 280px;
-      background: var(--panel);
-      padding: 24px 24px 48px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
       transform: translateX(-100%);
       transition: transform 0.35s ease;
       z-index: 1000;
@@ -98,6 +100,12 @@
       transform: translateX(4px);
     }
 
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
     .icon {
       font-size: 1.2rem;
       width: 22px;
@@ -117,6 +125,65 @@
 
     .hamburger.open {
       left: 300px;
+    }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.55);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease;
+      z-index: 900;
+    }
+
+    .overlay.show {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
     }
 
     /* MAIN */
@@ -200,6 +267,22 @@
       .actions { flex-direction: row; flex-wrap: wrap; }
       .btn { flex: 1; }
     }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
+    }
   </style>
 </head>
 <body>
@@ -211,7 +294,7 @@
       
     </div>
 
-    <a href="index.html"><span class="icon">🏠</span> Home</a>
+    <a href="index.html" class="active"><span class="icon">🏠</span> Home</a>
     <a href="generate.html"><span class="icon">✨</span> Generate</a>
     <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
     <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
@@ -240,6 +323,14 @@
       </div>
     </div>
   </div>
+
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html" class="active"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
 
   <script>
     const nav = document.getElementById('nav');

--- a/generate.html
+++ b/generate.html
@@ -1,38 +1,294 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <title>Atom Bowl — Generate</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="apple-touch-icon" href="favicon.png">
-  <title>Under Development</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg: #0b0f14;
+      --panel: #121824;
+      --accent: #4f7cff;
+      --text: #e6eaf0;
+      --muted: #9aa4b2;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      overflow-x: hidden;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: -20vh -20vw;
+      background:
+        radial-gradient(900px 500px at 20% 10%, rgba(79,124,255,0.28), transparent 55%),
+        radial-gradient(700px 420px at 80% 20%, rgba(57,217,138,0.14), transparent 60%),
+        radial-gradient(900px 520px at 60% 90%, rgba(255,107,107,0.12), transparent 62%);
+      filter: blur(18px);
+      opacity: 0.9;
+      animation: drift 14s ease-in-out infinite alternate;
+      z-index: -2;
+      pointer-events: none;
+    }
+
+    @keyframes drift {
+      from { transform: translate3d(-1.2%, -0.8%, 0) scale(1); }
+      to   { transform: translate3d( 1.2%,  0.9%, 0) scale(1.02); }
+    }
+
+    /* NAV */
+    .nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 100vh;
+      width: 280px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
+      transform: translateX(-100%);
+      transition: transform 0.35s ease;
+      z-index: 1000;
+    }
+
+    .nav.open { transform: translateX(0); }
+
+    .nav-title {
+      margin-top: 0;
+      font-weight: 700;
+      letter-spacing: 0.6px;
+      font-size: 1.4rem;
+      margin-bottom: 24px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .nav a {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      margin: 12px 0;
+      padding: 12px 14px;
+      border-radius: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 500;
+      transition: background 0.25s, color 0.25s, transform 0.15s;
+    }
+
+    .nav a:hover {
+      background: rgba(79, 124, 255, 0.15);
+      color: var(--accent);
+      transform: translateX(4px);
+    }
+
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
+    .icon {
+      font-size: 1.2rem;
+      width: 22px;
+      text-align: center;
+    }
+
+    .hamburger {
+      position: fixed;
+      top: 20px;
+      left: 20px;
+      font-size: 28px;
+      cursor: pointer;
+      z-index: 1100;
+      user-select: none;
+      transition: left 0.35s ease;
+    }
+
+    .hamburger.open { left: 300px; }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.55);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease;
+      z-index: 900;
+    }
+
+    .overlay.show {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .main {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: 120px 24px 140px;
+      text-align: center;
+    }
+
+    .card {
+      background: linear-gradient(145deg, #141b2e, #0f1524);
+      border-radius: 22px;
+      padding: 48px 42px;
+      max-width: 560px;
+      box-shadow: 0 30px 80px rgba(0,0,0,0.45);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .card h1 {
+      margin-top: 0;
+      font-size: 2.2rem;
+      margin-bottom: 10px;
+    }
+
+    .card p {
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin-bottom: 24px;
+    }
+
+    .card a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 18px;
+      border-radius: 12px;
+      background: #4f7cff;
+      color: white;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 120px 20px 180px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
+    }
+  </style>
 </head>
-<body style="
-  margin:0;
-  min-height:100vh;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  font-family:system-ui, sans-serif;
-  background:#0b0f14;
-  color:#e6eaf0;
-  text-align:center;
-">
+<body>
+  <div class="nav" id="nav">
+    <h2 class="nav-title">⚛ Atom Bowl</h2>
+    <a href="index.html"><span class="icon">🏠</span> Home</a>
+    <a href="generate.html" class="active"><span class="icon">✨</span> Generate</a>
+    <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
+    <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
+    <a href="settings.html"><span class="icon">⚙️</span> Settings</a>
+  </div>
 
-  <h1>This page is currently under development.</h1>
-  <p>Please check back soon. Sorry for the inconvenience.</p>
+  <div class="overlay" id="overlay"></div>
+  <div class="hamburger" id="hamburger">☰</div>
 
-  <a href="index.html" style="
-    margin-top:20px;
-    padding:12px 18px;
-    border-radius:12px;
-    background:#4f7cff;
-    color:white;
-    font-weight:700;
-    text-decoration:none;
-  ">
-    Return Home
-  </a>
+  <main class="main">
+    <div class="card">
+      <h1>This page is currently under development.</h1>
+      <p>Please check back soon. Sorry for the inconvenience.</p>
+      <a href="index.html">🏠 Return Home</a>
+    </div>
+  </main>
 
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html" class="active"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
+
+  <script>
+    const nav = document.getElementById('nav');
+    const overlay = document.getElementById('overlay');
+    const hamburger = document.getElementById('hamburger');
+
+    function toggleNav() {
+      const isOpen = nav.classList.toggle('open');
+      overlay.classList.toggle('show');
+      hamburger.classList.toggle('open');
+      hamburger.textContent = isOpen ? '✕' : '☰';
+    }
+
+    hamburger.addEventListener('click', toggleNav);
+    overlay.addEventListener('click', toggleNav);
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -38,8 +38,10 @@
       left: 0;
       height: 100vh;
       width: 280px;
-      background: var(--panel);
-      padding: 24px 24px 48px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
       transform: translateX(-100%);
       transition: transform 0.35s ease;
       z-index: 1000;
@@ -77,6 +79,12 @@
       background: rgba(79, 124, 255, 0.15);
       color: var(--accent);
       transform: translateX(4px);
+    }
+
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
     }
 
     .icon {
@@ -172,6 +180,70 @@
       opacity: 1;
       pointer-events: auto;
     }
+
+    /* ===== BOTTOM NAV (MOBILE) ===== */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 80px 20px 160px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
+    }
   </style>
 </head>
 <body>
@@ -183,7 +255,7 @@
       
     </div>
 
-    <a href="index.html"><span class="icon">🏠</span> Home</a>
+    <a href="index.html" class="active"><span class="icon">🏠</span> Home</a>
     <a href="generate.html"><span class="icon">✨</span> Generate</a>
     <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
     <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
@@ -225,6 +297,14 @@
       
     </div>
   </div>
+
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html" class="active"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
 
   <script>
     const nav = document.getElementById('nav');

--- a/practice.html
+++ b/practice.html
@@ -88,8 +88,10 @@
       left: 0;
       height: 100vh;
       width: 280px;
-      background: var(--panel);
-      padding: 24px 24px 48px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
       transform: translateX(-100%);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
@@ -125,6 +127,12 @@
       transform: translateX(4px);
     }
 
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
     .icon { width: 22px; text-align: center; }
 
     .hamburger {
@@ -153,6 +161,70 @@
     .overlay.show {
       opacity: 1;
       pointer-events: auto;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 96px 20px 170px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
     }
 
     /* Engine UI */
@@ -572,7 +644,7 @@
     <h2 class="nav-title">⚛ Atom Bowl</h2>
     <a href="index.html"><span class="icon">🏠</span> Home</a>
     <a href="generate.html"><span class="icon">✨</span> Generate</a>
-    <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
+    <a href="practice_home.html" class="active"><span class="icon">⚡</span> Practice</a>
     <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
     <a href="settings.html"><span class="icon">⚙️</span> Settings</a>
   </div>
@@ -681,6 +753,14 @@
 
     </div>
   </div>
+
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html" class="active"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
 
   <script>
     // NAV

--- a/practice_home.html
+++ b/practice_home.html
@@ -87,8 +87,10 @@
       left: 0;
       height: 100vh;
       width: 280px;
-      background: var(--panel);
-      padding: 24px 24px 48px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
       transform: translateX(-100%);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
@@ -124,6 +126,12 @@
       transform: translateX(4px);
     }
 
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
     .icon { width: 22px; text-align: center; }
 
     .hamburger {
@@ -152,6 +160,70 @@
     .overlay.show {
       opacity: 1;
       pointer-events: auto;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 96px 20px 170px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
     }
 
     /* MAIN */
@@ -318,7 +390,7 @@
     <h2 class="nav-title">⚛ Atom Bowl</h2>
     <a href="index.html"><span class="icon">🏠</span> Home</a>
     <a href="generate.html"><span class="icon">✨</span> Generate</a>
-    <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
+    <a href="practice_home.html" class="active"><span class="icon">⚡</span> Practice</a>
     <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
     <a href="settings.html"><span class="icon">⚙️</span> Settings</a>
   </div>
@@ -488,6 +560,14 @@
     </div>
 
   </div>
+
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html" class="active"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
 
   <script>
     // Everything waits for DOM so we never attach listeners to null nodes.

--- a/question_bank.html
+++ b/question_bank.html
@@ -85,8 +85,10 @@
       left: 0;
       height: 100vh;
       width: 280px;
-      background: var(--panel);
-      padding: 24px 24px 48px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
       transform: translateX(-100%);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
@@ -122,6 +124,12 @@
       transform: translateX(4px);
     }
 
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
     .icon { width: 22px; text-align: center; }
 
     .hamburger {
@@ -150,6 +158,70 @@
     .overlay.show {
       opacity: 1;
       pointer-events: auto;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 90px 20px 170px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
     }
 
     /* Page */
@@ -433,7 +505,7 @@
     <a href="index.html"><span class="icon">🏠</span> Home</a>
     <a href="generate.html"><span class="icon">✨</span> Generate</a>
     <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
-    <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
+    <a href="question_bank.html" class="active"><span class="icon">📚</span> Question Bank</a>
     <a href="settings.html"><span class="icon">⚙️</span> Settings</a>
   </div>
 
@@ -449,6 +521,12 @@
 
       <div class="controls">
         <input id="search" class="input" placeholder="Search (set, round, category, answer...)" />
+
+        <select id="bankSelect" class="select">
+          <option value="ALL">Bank: All</option>
+          <option value="set_A.json">Bank A (Image Questions)</option>
+          <option value="set_B.json">Bank B (Text Questions)</option>
+        </select>
 
         <select id="level" class="select">
           <option value="ANY">Level: Any</option>
@@ -495,6 +573,14 @@
     <div id="err" class="error" style="display:none"></div>
   </div>
 
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html" class="active"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
+
   <script>
     // NAV
     const nav = document.getElementById('nav');
@@ -514,6 +600,7 @@
     const errEl = document.getElementById('err');
     const countEl = document.getElementById('count');
     const searchEl = document.getElementById('search');
+    const bankSelectEl = document.getElementById('bankSelect');
     const levelEl = document.getElementById('level');
     const categoryEl = document.getElementById('category');
     const bonusEl = document.getElementById('bonus');
@@ -541,13 +628,24 @@
     }
 
     async function loadBank() {
-      const res = await fetch('./set_A.json', { cache: 'no-store' });
-      if (!res.ok) throw new Error('set_A.json not found in repo root');
-      const data = await res.json();
-      return Array.isArray(data) ? data : (data.questions || []);
+      const sources = [
+        { id: 'set_A.json', label: 'Bank A' },
+        { id: 'set_B.json', label: 'Bank B' }
+      ];
+
+      const results = await Promise.all(sources.map(async (source) => {
+        const res = await fetch(`./${source.id}`, { cache: 'no-store' });
+        if (!res.ok) throw new Error(`${source.id} not found in repo root`);
+        const data = await res.json();
+        const items = Array.isArray(data) ? data : (data.questions || []);
+        return items.map((q) => ({ ...q, bank_id: source.id, bank_label: source.label }));
+      }));
+
+      return results.flat();
     }
 
-    function matches(q, search, level, category, bonus) {
+    function matches(q, search, bankChoice, level, category, bonus) {
+      if (bankChoice !== 'ALL' && q.bank_id !== bankChoice) return false;
       if (level !== 'ANY' && q.level !== level) return false;
       if (category !== 'ANY' && norm(q.category) !== category) return false;
       if (bonus !== 'ANY' && String(!!q.bonus) !== String(bonus)) return false;
@@ -570,11 +668,12 @@
 
     function apply() {
       const search = norm(searchEl.value);
+      const bankChoice = bankSelectEl.value;
       const level = levelEl.value;
       const category = categoryEl.value;
       const bonus = bonusEl.value;
 
-      filtered = bank.filter(q => matches(q, search, level, category, bonus));
+      filtered = bank.filter(q => matches(q, search, bankChoice, level, category, bonus));
       page = 1;
       render();
     }
@@ -677,6 +776,7 @@
     })();
 
     searchEl.addEventListener('input', () => debounced(apply));
+    bankSelectEl.addEventListener('change', apply);
     levelEl.addEventListener('change', apply);
     categoryEl.addEventListener('change', apply);
     bonusEl.addEventListener('change', apply);
@@ -685,7 +785,7 @@
     nextBtn.addEventListener('click', () => { page += 1; render(); window.scrollTo({ top: 0, behavior: 'smooth' }); });
 
     (async () => {
-      statusEl.textContent = 'Loading set_A.json…';
+      statusEl.textContent = 'Loading question banks…';
       try {
         bank = await loadBank();
       } catch (e) {
@@ -701,7 +801,7 @@
         return;
       }
 
-      statusEl.textContent = `Loaded ${bank.length} questions.`;
+      statusEl.textContent = `Loaded ${bank.length} questions from both banks.`;
       filtered = bank.slice();
       render();
     })();

--- a/settings.html
+++ b/settings.html
@@ -87,8 +87,10 @@
       left: 0;
       height: 100vh;
       width: 280px;
-      background: var(--panel);
-      padding: 24px 24px 48px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
       transform: translateX(-100%);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
@@ -124,6 +126,12 @@
       transform: translateX(4px);
     }
 
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
     .icon { width: 22px; text-align: center; }
 
     .hamburger {
@@ -152,6 +160,70 @@
     .overlay.show {
       opacity: 1;
       pointer-events: auto;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 96px 20px 170px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
     }
 
     /* Page */
@@ -372,7 +444,7 @@
     <a href="generate.html"><span class="icon">✨</span> Generate</a>
     <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
     <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
-    <a href="settings.html"><span class="icon">⚙️</span> Settings</a>
+    <a href="settings.html" class="active"><span class="icon">⚙️</span> Settings</a>
   </div>
 
   <div class="overlay" id="overlay"></div>
@@ -481,6 +553,14 @@
       <a class="btn" href="index.html" style="text-decoration:none; display:inline-flex; align-items:center;">Back to Home</a>
     </div>
   </div>
+
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html" class="active"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
 
   <div class="toast" id="toast">Saved ✅</div>
 

--- a/tutor.html
+++ b/tutor.html
@@ -1,38 +1,294 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <title>Atom Bowl — Tutor</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="apple-touch-icon" href="favicon.png">
-  <title>Under Development</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --bg: #0b0f14;
+      --panel: #121824;
+      --accent: #4f7cff;
+      --text: #e6eaf0;
+      --muted: #9aa4b2;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      overflow-x: hidden;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: -20vh -20vw;
+      background:
+        radial-gradient(900px 500px at 20% 10%, rgba(79,124,255,0.28), transparent 55%),
+        radial-gradient(700px 420px at 80% 20%, rgba(57,217,138,0.14), transparent 60%),
+        radial-gradient(900px 520px at 60% 90%, rgba(255,107,107,0.12), transparent 62%);
+      filter: blur(18px);
+      opacity: 0.9;
+      animation: drift 14s ease-in-out infinite alternate;
+      z-index: -2;
+      pointer-events: none;
+    }
+
+    @keyframes drift {
+      from { transform: translate3d(-1.2%, -0.8%, 0) scale(1); }
+      to   { transform: translate3d( 1.2%,  0.9%, 0) scale(1.02); }
+    }
+
+    /* NAV */
+    .nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 100vh;
+      width: 280px;
+      background: linear-gradient(180deg, rgba(18,24,36,0.98), rgba(11,15,22,0.96));
+      padding: 26px 24px 48px;
+      border-right: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 18px 0 60px rgba(0,0,0,0.45);
+      transform: translateX(-100%);
+      transition: transform 0.35s ease;
+      z-index: 1000;
+    }
+
+    .nav.open { transform: translateX(0); }
+
+    .nav-title {
+      margin-top: 0;
+      font-weight: 700;
+      letter-spacing: 0.6px;
+      font-size: 1.4rem;
+      margin-bottom: 24px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .nav a {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      margin: 12px 0;
+      padding: 12px 14px;
+      border-radius: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 500;
+      transition: background 0.25s, color 0.25s, transform 0.15s;
+    }
+
+    .nav a:hover {
+      background: rgba(79, 124, 255, 0.15);
+      color: var(--accent);
+      transform: translateX(4px);
+    }
+
+    .nav a.active {
+      background: rgba(79, 124, 255, 0.2);
+      color: #d7e2ff;
+      box-shadow: inset 0 0 0 1px rgba(79, 124, 255, 0.35);
+    }
+
+    .icon {
+      font-size: 1.2rem;
+      width: 22px;
+      text-align: center;
+    }
+
+    .hamburger {
+      position: fixed;
+      top: 20px;
+      left: 20px;
+      font-size: 28px;
+      cursor: pointer;
+      z-index: 1100;
+      user-select: none;
+      transition: left 0.35s ease;
+    }
+
+    .hamburger.open { left: 300px; }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.55);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease;
+      z-index: 900;
+    }
+
+    .overlay.show {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .main {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: 120px 24px 140px;
+      text-align: center;
+    }
+
+    .card {
+      background: linear-gradient(145deg, #141b2e, #0f1524);
+      border-radius: 22px;
+      padding: 48px 42px;
+      max-width: 560px;
+      box-shadow: 0 30px 80px rgba(0,0,0,0.45);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .card h1 {
+      margin-top: 0;
+      font-size: 2.2rem;
+      margin-bottom: 10px;
+    }
+
+    .card p {
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin-bottom: 24px;
+    }
+
+    .card a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 18px;
+      border-radius: 12px;
+      background: #4f7cff;
+      color: white;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    /* Bottom nav */
+    .bottom-nav {
+      position: fixed;
+      left: 12px;
+      right: 12px;
+      bottom: 14px;
+      padding: 10px 12px;
+      border-radius: 22px;
+      background: rgba(12,16,26,0.92);
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+      display: none;
+      justify-content: space-around;
+      gap: 8px;
+      z-index: 1200;
+      backdrop-filter: blur(8px);
+    }
+
+    .bottom-nav a {
+      flex: 1;
+      text-decoration: none;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 6px;
+      border-radius: 14px;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .bottom-nav a .icon {
+      font-size: 1.15rem;
+    }
+
+    .bottom-nav a.active {
+      color: var(--text);
+      background: rgba(79,124,255,0.22);
+      box-shadow: inset 0 0 0 1px rgba(79,124,255,0.4);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 820px) {
+      .nav,
+      .overlay,
+      .hamburger {
+        display: none;
+      }
+
+      body {
+        padding-bottom: 120px;
+      }
+
+      .main {
+        padding: 120px 20px 180px;
+      }
+
+      .bottom-nav {
+        display: flex;
+      }
+    }
+  </style>
 </head>
-<body style="
-  margin:0;
-  min-height:100vh;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  font-family:system-ui, sans-serif;
-  background:#0b0f14;
-  color:#e6eaf0;
-  text-align:center;
-">
+<body>
+  <div class="nav" id="nav">
+    <h2 class="nav-title">⚛ Atom Bowl</h2>
+    <a href="index.html"><span class="icon">🏠</span> Home</a>
+    <a href="generate.html"><span class="icon">✨</span> Generate</a>
+    <a href="practice_home.html"><span class="icon">⚡</span> Practice</a>
+    <a href="question_bank.html"><span class="icon">📚</span> Question Bank</a>
+    <a href="settings.html"><span class="icon">⚙️</span> Settings</a>
+  </div>
 
-  <h1>This page is currently under development.</h1>
-  <p>Please check back soon. Sorry for the inconvenience.</p>
+  <div class="overlay" id="overlay"></div>
+  <div class="hamburger" id="hamburger">☰</div>
 
-  <a href="question_bank.html" style="
-    margin-top:20px;
-    padding:12px 18px;
-    border-radius:12px;
-    background:#4f7cff;
-    color:white;
-    font-weight:700;
-    text-decoration:none;
-  ">
-    Go Back
-  </a>
+  <main class="main">
+    <div class="card">
+      <h1>This page is currently under development.</h1>
+      <p>Please check back soon. Sorry for the inconvenience.</p>
+      <a href="question_bank.html">📚 Go Back</a>
+    </div>
+  </main>
 
+  <nav class="bottom-nav" aria-label="Primary">
+    <a href="index.html"><span class="icon">🏠</span><span>Home</span></a>
+    <a href="generate.html"><span class="icon">✨</span><span>Generate</span></a>
+    <a href="practice_home.html"><span class="icon">⚡</span><span>Practice</span></a>
+    <a href="question_bank.html"><span class="icon">📚</span><span>Bank</span></a>
+    <a href="settings.html"><span class="icon">⚙️</span><span>Settings</span></a>
+  </nav>
+
+  <script>
+    const nav = document.getElementById('nav');
+    const overlay = document.getElementById('overlay');
+    const hamburger = document.getElementById('hamburger');
+
+    function toggleNav() {
+      const isOpen = nav.classList.toggle('open');
+      overlay.classList.toggle('show');
+      hamburger.classList.toggle('open');
+      hamburger.textContent = isOpen ? '✕' : '☰';
+    }
+
+    hamburger.addEventListener('click', toggleNav);
+    overlay.addEventListener('click', toggleNav);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Refresh navigation styling to a cleaner, slightly elevated panel look and provide a compact, icon-first mobile navigation like Duolingo for improved UX across pages.
- Make the Question Bank able to show and filter across both banks so users can browse and pick which bank to use without duplicating pages.

### Description
- Reworked the shared nav visuals (gradient background, subtle right border, shadow, and an `.active` link style) and added a rounded, icon-driven bottom navigation for small screens; this was applied to `index.html`, `generate.html`, `practice.html`, `practice_home.html`, `question_bank.html`, `settings.html`, `404.html`, and `tutor.html`.
- Mobile behavior now hides the left sidebar/hamburger and shows the new bottom nav via an `@media (max-width: 820px)` rule and a `.bottom-nav` component with icon + label buttons.
- Updated `question_bank.html` to load both `set_A.json` and `set_B.json` in `loadBank()`, tag each question with `bank_id`/`bank_label`, add a `Bank` selector (`#bankSelect`), and wire filtering to respect the selected bank choice.
- Minor UX/text updates: status messages in the question bank now indicate multi-bank loading and total counts reflect combined banks.

### Testing
- Launched a local static server and used Playwright to open `/question_bank.html` at a mobile viewport and capture a screenshot, which succeeded and produced an artifact (`question_bank_mobile.png`).
- Verified the Question Bank page loads both banks and the bank selector triggers filtering in the browser (manual/interactive validation during the Playwright run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8eb005ac8323944a1ba8226ceb59)