### PR TITLE
Fix bank loading paths in static pages

### DIFF
--- a/docs/practice_home.html
+++ b/docs/practice_home.html
@@ -409,7 +409,7 @@
           <div style="font-weight:800;">Loaded Bank</div>
           <div class="badge" id="bankStatus">Checking…</div>
         </div>
-        <div class="mini" id="bankMeta">set_A.json</div>
+        <div class="mini" id="bankMeta">data/set_A.json</div>
       </div>
     </div>
 
@@ -423,8 +423,8 @@
         <div class="field">
           <label for="bankSelect">Question Bank</label>
           <select id="bankSelect">
-            <option value="set_A.json">Bank A (Image Questions)</option>
-            <option value="set_B.json">Bank B (Text Questions, Under Development)</option>
+            <option value="data/set_A.json">Bank A (Image Questions)</option>
+            <option value="data/set_B.json">Bank B (Text Questions, Under Development)</option>
           </select>
         </div>
 
@@ -677,25 +677,26 @@
       };
 
       async function loadBank() {
-        const selectedBank = els.bankSelect?.value || './data/set_A.json';
+        const selectedBank = els.bankSelect?.value || 'data/set_A.json';
+        const normalizedBank = selectedBank.replace(/^\.\/+/, '');
         try {
           els.bankStatus.textContent = 'Loading…';
-          const res = await fetch(`./${selectedBank}`, { cache: 'no-store' });
-          if (!res.ok) throw new Error('set_A.json not found');
+          const res = await fetch(`./${normalizedBank}`, { cache: 'no-store' });
+          if (!res.ok) throw new Error('data/set_A.json not found');
           const data = await res.json();
           bank = Array.isArray(data) ? data : (data.questions || []);
 
           els.bankStatus.textContent = 'Ready';
           els.bankStatus.style.background = 'rgba(57,217,138,0.14)';
           els.bankStatus.style.borderColor = 'rgba(57,217,138,0.24)';
-          els.bankMeta.textContent = `${selectedBank} • ${bank.length.toLocaleString()} questions detected`;
+          els.bankMeta.textContent = `${normalizedBank} • ${bank.length.toLocaleString()} questions detected`;
 
           updateCounts();
         } catch (e) {
           els.bankStatus.textContent = 'Missing';
           els.bankStatus.style.background = 'rgba(255,107,107,0.14)';
           els.bankStatus.style.borderColor = 'rgba(255,107,107,0.22)';
-          els.bankMeta.textContent = 'Put the sets in the repo root (same folder as this file).';
+          els.bankMeta.textContent = 'Put the sets in docs/data (data/ on the site).';
           bank = [];
           updateCounts();
         }

--- a/docs/question_bank.html
+++ b/docs/question_bank.html
@@ -524,8 +524,8 @@
 
         <select id="bankSelect" class="select">
           <option value="ALL">Bank: All</option>
-          <option value="set_A.json">Bank A (Image Questions)</option>
-          <option value="set_B.json">Bank B (Text Questions)</option>
+          <option value="data/set_A.json">Bank A (Image Questions)</option>
+          <option value="data/set_B.json">Bank B (Text Questions)</option>
         </select>
 
         <select id="level" class="select">
@@ -629,13 +629,13 @@
 
     async function loadBank() {
       const sources = [
-        { id: 'set_A.json', label: 'Bank A' },
-        { id: 'set_B.json', label: 'Bank B' }
+        { id: 'data/set_A.json', label: 'Bank A' },
+        { id: 'data/set_B.json', label: 'Bank B' }
       ];
 
       const results = await Promise.all(sources.map(async (source) => {
         const res = await fetch(`./${source.id}`, { cache: 'no-store' });
-        if (!res.ok) throw new Error(`${source.id} not found in repo root`);
+        if (!res.ok) throw new Error(`${source.id} not found in /data`);
         const data = await res.json();
         const items = Array.isArray(data) ? data : (data.questions || []);
         return items.map((q) => ({ ...q, bank_id: source.id, bank_label: source.label }));
@@ -796,7 +796,7 @@
 
       // Basic sanity
       if (!Array.isArray(bank) || bank.length === 0) {
-        showErr('set_A.json loaded but contains no questions.');
+        showErr('data/set_A.json loaded but contains no questions.');
         statusEl.textContent = '';
         return;
       }


### PR DESCRIPTION
### Motivation
- The question bank and practice pages were attempting to load JSON files from the repo root while the JSON assets live under `docs/data/`, causing banks to not load in the UI. 
- Path normalization and clearer status messaging were needed so users see correct guidance when a bank is missing.

### Description
- Updated the `question_bank.html` bank options and loader to point to `data/set_A.json` and `data/set_B.json` and to throw a clearer error when files are not found in `/data`.
- Updated the `practice_home.html` bank select options to use `data/` paths, added `normalizedBank = selectedBank.replace(/^\.\/+/, '')` and use `fetch(./${normalizedBank})` to avoid `././` issues, and adjusted the missing-bank guidance to point at `docs/data`.
- Adjusted displayed metadata (`bankMeta`) and error text to reference the `data/` location so status indicators reflect the actual asset layout.
- Changes applied to `docs/question_bank.html` and `docs/practice_home.html` to fix bank resolution and user-facing messages.

### Testing
- Automated tests were not run because these are static HTML/JS path fixes and no test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ff044e6f08323aea05b3ba94e50f7)