### PR TITLE
Make desktop nav persistent on left (hide hamburger/overlay)

### DIFF
--- a/docs/css/404.css
+++ b/docs/css/404.css
@@ -47,7 +47,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.35s ease;
       z-index: 1000;
     }
@@ -96,6 +96,11 @@
       font-size: 1.2rem;
       width: 22px;
       text-align: center;
+    }
+
+    .hamburger,
+    .overlay {
+      display: none;
     }
 
     .hamburger {
@@ -179,6 +184,8 @@
       align-items: center;
       justify-content: center;
       padding: 24px;
+      margin-left: 280px;
+      width: calc(100% - 280px);
     }
 
     .card {
@@ -263,6 +270,11 @@
 
       body {
         padding-bottom: 120px;
+      }
+
+      .container {
+        margin-left: 0;
+        width: 100%;
       }
 
       .bottom-nav {

--- a/docs/css/generate.css
+++ b/docs/css/generate.css
@@ -47,7 +47,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.35s ease;
       z-index: 1000;
     }
@@ -96,6 +96,11 @@
       text-align: center;
     }
 
+    .hamburger,
+    .overlay {
+      display: none;
+    }
+
     .hamburger {
       position: fixed;
       top: 20px;
@@ -132,6 +137,8 @@
       align-items: center;
       padding: 120px 24px 140px;
       text-align: center;
+      margin-left: 280px;
+      width: calc(100% - 280px);
     }
 
     .card {
@@ -224,6 +231,8 @@
 
       .main {
         padding: 120px 20px 180px;
+        margin-left: 0;
+        width: 100%;
       }
 
       .bottom-nav {

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -27,7 +27,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.35s ease;
       z-index: 1000;
     }
@@ -78,6 +78,11 @@
       text-align: center;
     }
 
+    .hamburger,
+    .overlay {
+      display: none;
+    }
+
     .hamburger {
       position: fixed;
       top: 20px;
@@ -97,7 +102,8 @@
     .main {
       padding: 100px 32px 120px;
       max-width: 1200px;
-      margin: auto;
+      margin: 0 auto 0 280px;
+      width: calc(100% - 280px);
       min-height: 100vh;
     }
 
@@ -223,6 +229,8 @@
 
       .main {
         padding: 80px 20px 160px;
+        margin: 0 auto;
+        width: auto;
       }
 
       .bottom-nav {

--- a/docs/css/practice.css
+++ b/docs/css/practice.css
@@ -78,7 +78,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
     }
@@ -120,6 +120,11 @@
     }
 
     .icon { width: 22px; text-align: center; }
+
+    .hamburger,
+    .overlay {
+      display: none;
+    }
 
     .hamburger {
       position: fixed;
@@ -206,6 +211,8 @@
 
       .main {
         padding: 96px 20px 170px;
+        margin: 0 auto;
+        width: auto;
       }
 
       .bottom-nav {
@@ -217,7 +224,8 @@
     .main {
       padding: 112px 24px 140px;
       max-width: 960px;
-      margin: auto;
+      margin: 0 auto 0 280px;
+      width: calc(100% - 280px);
       min-height: 100vh;
     }
 

--- a/docs/css/practice_home.css
+++ b/docs/css/practice_home.css
@@ -77,7 +77,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
     }
@@ -119,6 +119,11 @@
     }
 
     .icon { width: 22px; text-align: center; }
+
+    .hamburger,
+    .overlay {
+      display: none;
+    }
 
     .hamburger {
       position: fixed;
@@ -205,6 +210,8 @@
 
       .main {
         padding: 96px 20px 170px;
+        margin: 0 auto;
+        width: auto;
       }
 
       .bottom-nav {
@@ -216,7 +223,8 @@
     .main {
       padding: 100px 24px 120px;
       max-width: 1100px;
-      margin: auto;
+      margin: 0 auto 0 280px;
+      width: calc(100% - 280px);
       min-height: 100vh;
     }
 

--- a/docs/css/question_bank.css
+++ b/docs/css/question_bank.css
@@ -75,7 +75,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
     }
@@ -117,6 +117,11 @@
     }
 
     .icon { width: 22px; text-align: center; }
+
+    .hamburger,
+    .overlay {
+      display: none;
+    }
 
     .hamburger {
       position: fixed;
@@ -203,6 +208,8 @@
 
       .main {
         padding: 90px 20px 170px;
+        margin: 0 auto;
+        width: auto;
       }
 
       .bottom-nav {
@@ -214,7 +221,8 @@
     .main {
       padding: 112px 24px 140px;
       max-width: 1280px;
-      margin: auto;
+      margin: 0 auto 0 280px;
+      width: calc(100% - 280px);
       min-height: 100vh;
     }
 

--- a/docs/css/settings.css
+++ b/docs/css/settings.css
@@ -77,7 +77,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.42s cubic-bezier(.2,.9,.2,1);
       z-index: 1000;
     }
@@ -119,6 +119,11 @@
     }
 
     .icon { width: 22px; text-align: center; }
+
+    .hamburger,
+    .overlay {
+      display: none;
+    }
 
     .hamburger {
       position: fixed;
@@ -205,6 +210,8 @@
 
       .main {
         padding: 96px 20px 170px;
+        margin: 0 auto;
+        width: auto;
       }
 
       .bottom-nav {
@@ -216,7 +223,8 @@
     .main {
       padding: 112px 24px 140px;
       max-width: 1100px;
-      margin: auto;
+      margin: 0 auto 0 280px;
+      width: calc(100% - 280px);
       min-height: 100vh;
     }
 

--- a/docs/css/tutor.css
+++ b/docs/css/tutor.css
@@ -47,7 +47,7 @@
       padding: 26px 24px 48px;
       border-right: 1px solid rgba(255,255,255,0.06);
       box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-      transform: translateX(-100%);
+      transform: translateX(0);
       transition: transform 0.35s ease;
       z-index: 1000;
     }
@@ -96,6 +96,11 @@
       text-align: center;
     }
 
+    .hamburger,
+    .overlay {
+      display: none;
+    }
+
     .hamburger {
       position: fixed;
       top: 20px;
@@ -132,6 +137,8 @@
       align-items: center;
       padding: 120px 24px 140px;
       text-align: center;
+      margin-left: 280px;
+      width: calc(100% - 280px);
     }
 
     .card {
@@ -224,6 +231,8 @@
 
       .main {
         padding: 120px 20px 180px;
+        margin-left: 0;
+        width: 100%;
       }
 
       .bottom-nav {


### PR DESCRIPTION
### Motivation
- Provide a Duolingo-style persistent left sidebar on desktop so the nav is always visible on larger screens. 
- Remove the mobile-style hamburger/overlay interaction on desktop and shift main content to account for the fixed sidebar.

### Description
- Updated CSS across the site to make the nav persist by setting `.nav` to `transform: translateX(0)` on desktop and hiding `.hamburger` and `.overlay` (`display: none`).
- Shifted main content and containers to accommodate the 280px sidebar by applying `margin-left: 280px` and `width: calc(100% - 280px)` where appropriate.
- Restored mobile behavior inside the existing media queries (`@media (max-width: 820px)`) by resetting margins/width so the bottom mobile nav remains unchanged.
- Files changed: `docs/css/index.css`, `docs/css/generate.css`, `docs/css/practice.css`, `docs/css/practice_home.css`, `docs/css/question_bank.css`, `docs/css/settings.css`, `docs/css/tutor.css`, and `docs/css/404.css`.

### Testing
- Launched a local server with `python -m http.server` and attempted an automated Playwright screenshot of `http://127.0.0.1:8000/index.html`, but the headless browser crashed with a `TargetClosedError` and the screenshot step failed. 
- No other automated tests were run; changes are static CSS updates and were verified by inspecting the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f4f88f388323a2923a88469cde04)