### PR TITLE
Add multi-select topic grid and filter support for Practice

### DIFF
--- a/docs/css/404.css
+++ b/docs/css/404.css
@@ -254,6 +254,22 @@
       .btn { flex: 1; }
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .container {
+        margin-left: 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/css/generate.css
+++ b/docs/css/generate.css
@@ -211,6 +211,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin-left: 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -210,6 +210,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin: 0 auto 0 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/css/practice.css
+++ b/docs/css/practice.css
@@ -193,6 +193,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin: 0 auto 0 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/css/practice_home.css
+++ b/docs/css/practice_home.css
@@ -192,6 +192,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin: 0 auto 0 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,
@@ -258,6 +274,88 @@
       margin-top: 12px;
     }
 
+    .topic-panel {
+      margin-top: 18px;
+      border-radius: 18px;
+      padding: 16px;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: rgba(11,15,24,0.55);
+    }
+
+    .topic-panel-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 14px;
+    }
+
+    .topic-title {
+      font-weight: 800;
+      font-size: 1rem;
+    }
+
+    .topic-clear {
+      border: 1px solid rgba(255,255,255,0.12);
+      background: rgba(18,24,36,0.8);
+      color: var(--text);
+      border-radius: 10px;
+      padding: 8px 12px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 0.15s ease, border-color 0.15s ease;
+    }
+
+    .topic-clear:hover {
+      transform: translateY(-1px);
+      border-color: rgba(79,124,255,0.45);
+    }
+
+    .topic-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 14px;
+    }
+
+    .topic-column {
+      background: rgba(18,24,36,0.6);
+      border-radius: 14px;
+      padding: 12px;
+      border: 1px solid rgba(255,255,255,0.06);
+      display: grid;
+      gap: 10px;
+    }
+
+    .topic-super {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 800;
+      font-size: 0.9rem;
+      letter-spacing: 0.4px;
+      color: var(--text);
+    }
+
+    .topic-sublist {
+      display: grid;
+      gap: 6px;
+    }
+
+    .topic-option {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      font-size: 0.82rem;
+      color: var(--muted);
+      line-height: 1.3;
+    }
+
+    .topic-option input,
+    .topic-super input {
+      margin-top: 2px;
+    }
+
     .field { display: grid; gap: 6px; }
 
     label {
@@ -282,8 +380,6 @@
       border-color: rgba(79,124,255,0.55);
       box-shadow: 0 0 0 6px rgba(79,124,255,0.10);
     }
-
-    /* Category (single-select dropdown) */
 
     .grid {
       display: grid;

--- a/docs/css/question_bank.css
+++ b/docs/css/question_bank.css
@@ -190,6 +190,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin: 0 auto 0 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/css/settings.css
+++ b/docs/css/settings.css
@@ -192,6 +192,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin: 0 auto 0 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/css/tutor.css
+++ b/docs/css/tutor.css
@@ -211,6 +211,22 @@
       transform: translateY(-1px);
     }
 
+    @media (min-width: 821px) {
+      .nav {
+        transform: translateX(0);
+      }
+
+      .hamburger,
+      .overlay {
+        display: none;
+      }
+
+      .main {
+        margin-left: 280px;
+        width: calc(100% - 280px);
+      }
+    }
+
     @media (max-width: 820px) {
       .nav,
       .overlay,

--- a/docs/js/practice.js
+++ b/docs/js/practice.js
@@ -18,6 +18,8 @@
       mode: 'rapid',
       level: 'ANY',
       category: 'ANY',
+      categories: [],
+      detailedCategories: [],
       qaType: 'ANY',
       bonus: 'ANY',
       count: 25,     // rapid mode: number of PAIRS
@@ -39,7 +41,30 @@
       ...cfg
     };
 
+    const TOPIC_GROUPS = [
+      { id: 'PHYSICS', categories: ['PHYSICS', 'PHYSICAL SCIENCE'] },
+      { id: 'CHEMISTRY', categories: ['CHEMISTRY'] },
+      { id: 'MATH', categories: ['MATH', 'MATHEMATICS'] },
+      { id: 'EARTH_SCIENCE', categories: ['EARTH SCIENCE', 'EARTH AND SPACE', 'EARTH AND SPACE SCIENCE'] },
+      { id: 'ASTRONOMY', categories: ['ASTRONOMY'] },
+      { id: 'BIOLOGY', categories: ['BIOLOGY', 'LIFE SCIENCE'] },
+      { id: 'GENERAL_SCIENCE', categories: ['GENERAL SCIENCE'] },
+      { id: 'ENERGY', categories: ['ENERGY'] },
+    ];
+
+    function expandCategories(selectedTopics) {
+      if (!Array.isArray(selectedTopics) || !selectedTopics.length) return [];
+      const lookup = new Map(TOPIC_GROUPS.map(group => [group.id, group.categories]));
+      return selectedTopics.flatMap(topic => lookup.get(topic) || []);
+    }
+
     runCfg.qaType = runCfg.qaType || runCfg.qtype || 'ANY';
+    if (!Array.isArray(runCfg.categories)) {
+      runCfg.categories = [];
+    }
+    if (!Array.isArray(runCfg.detailedCategories)) {
+      runCfg.detailedCategories = [];
+    }
 
     runCfg.seconds = parseInt(runCfg.seconds ?? runCfg.time, 10);
     if (!Number.isFinite(runCfg.seconds)) runCfg.seconds = DEFAULT_RUN.seconds;
@@ -384,6 +409,8 @@
     function applyFilters(list) {
       const level = runCfg.level;
       const category = runCfg.category;
+      const categories = expandCategories(runCfg.categories);
+      const detailedCategories = runCfg.detailedCategories || [];
       const qaType = runCfg.qaType;
       const bonus = runCfg.bonus;
       const setName = norm(runCfg.setName);
@@ -391,7 +418,12 @@
 
       return list.filter(q => {
         if (level !== 'ANY' && q.level !== level) return false;
-        if (category !== 'ANY' && norm(q.category) !== category) return false;
+        if (categories.length && !categories.includes(norm(q.category))) return false;
+        if (!categories.length && category !== 'ANY' && norm(q.category) !== category) return false;
+        if (detailedCategories.length) {
+          const detailed = norm(q.detailed_category || q.detailedCategory);
+          if (!detailedCategories.includes(detailed)) return false;
+        }
         if (qaType !== 'ANY' && q.type !== qaType) return false;
 
         // bonus can be ANY / true / false / TU / BONUS

--- a/docs/js/practice_home.js
+++ b/docs/js/practice_home.js
@@ -19,7 +19,6 @@
       const els = {
         bankSelect: document.getElementById('bankSelect'),
         level: document.getElementById('level'),
-        category: document.getElementById('category'),
         qaType: document.getElementById('qaType'),
         bonus: document.getElementById('bonus'),
         count: document.getElementById('count'),
@@ -28,6 +27,8 @@
         roundName: document.getElementById('roundName'),
         bankStatus: document.getElementById('bankStatus'),
         bankMeta: document.getElementById('bankMeta'),
+        topicGrid: document.getElementById('topicGrid'),
+        clearTopics: document.getElementById('clearTopics'),
         countRapid: document.getElementById('countRapid'),
         countToss: document.getElementById('countToss'),
         countBonus: document.getElementById('countBonus'),
@@ -37,17 +38,198 @@
       };
 
       // Minimal self-tests (console only)
-      console.assert(!!els.level && !!els.category && !!els.qaType && !!els.bonus, 'Missing core filter elements');
+      console.assert(!!els.level && !!els.qaType && !!els.bonus, 'Missing core filter elements');
       console.assert(!!els.countRapid && !!els.bankStatus, 'Missing status/count elements');
 
       let bank = [];
 
       function normCat(c) { return String(c || '').trim(); }
 
+      const TOPIC_GROUPS = [
+        {
+          id: 'PHYSICS',
+          label: 'PHYSICS',
+          categories: ['PHYSICS', 'PHYSICAL SCIENCE'],
+          detailed: [
+            'Kinematics',
+            'Newtonian Mechanics',
+            'Work, Energy, & Power',
+            'Momentum & Collisions',
+            'Rotational Motion',
+            'Waves & Sound',
+            'Optics',
+            'Electricity & Circuits',
+            'Magnetism',
+            'Electromagnetism',
+            'Modern Physics',
+            'Thermodynamics',
+            'Units, Constants, & Measurement',
+          ],
+        },
+        {
+          id: 'CHEMISTRY',
+          label: 'CHEM',
+          categories: ['CHEMISTRY'],
+          detailed: [
+            'Stoichiometry & Moles',
+            'Atomic Structure',
+            'Periodic Trends',
+            'Chemical Bonding',
+            'Thermochemistry',
+            'Gas Laws',
+            'Acids, Bases, & pH',
+            'Reaction Kinetics',
+            'Equilibrium',
+            'Electrochemistry',
+            'Organic Chemistry',
+            'Nuclear Chemistry',
+            'Solutions & Colligative Properties',
+            'Lab Techniques & Measurement',
+          ],
+        },
+        {
+          id: 'MATH',
+          label: 'MATH',
+          categories: ['MATH', 'MATHEMATICS'],
+          detailed: [
+            'Algebra',
+            'Geometry',
+            'Trigonometry',
+            'Analytic Geometry',
+            'Functions',
+            'Polynomials',
+            'Exponents & Radicals',
+            'Probability & Statistics',
+            'Number Theory',
+            'Word Problems',
+          ],
+        },
+        {
+          id: 'EARTH_SCIENCE',
+          label: 'ESS',
+          categories: ['EARTH SCIENCE', 'EARTH AND SPACE', 'EARTH AND SPACE SCIENCE'],
+          detailed: [
+            'Meteorology',
+            'Climatology',
+            'Atmospheric Physics',
+            'Geology',
+            'Mineralogy',
+            'Petrology',
+            'Plate Tectonics',
+            'Geomorphology',
+            'Hydrology',
+            'Oceanography',
+            'Earth Systems',
+            'Environmental Earth Science',
+          ],
+        },
+        {
+          id: 'ASTRONOMY',
+          label: 'ASTRO',
+          categories: ['ASTRONOMY'],
+          detailed: [
+            'Celestial Coordinates',
+            'Stars & Stellar Evolution',
+            'Galaxies & Cosmology',
+            'Solar System',
+            'Observational Astronomy',
+            'Astrophysics',
+            'Spectroscopy',
+            'Cosmology',
+            'Space Weather',
+          ],
+        },
+        {
+          id: 'BIOLOGY',
+          label: 'BIO',
+          categories: ['BIOLOGY', 'LIFE SCIENCE'],
+          detailed: [
+            'Cell Structure & Function',
+            'Biochemistry',
+            'Enzymes & Metabolism',
+            'Photosynthesis & Respiration',
+            'Genetics',
+            'Molecular Biology',
+            'Evolution',
+            'Ecology',
+            'Plant Biology',
+            'Human Physiology',
+            'Immunology',
+            'Microbiology',
+            'Taxonomy & Classification',
+          ],
+        },
+        {
+          id: 'GENERAL_SCIENCE',
+          label: 'GEN SCI',
+          categories: ['GENERAL SCIENCE'],
+          detailed: [
+            'Scientific Measurement',
+            'Dimensional Analysis',
+            'Scientific Notation',
+            'Laboratory Safety',
+            'Applied Science',
+            'Interdisciplinary Science',
+          ],
+        },
+        {
+          id: 'ENERGY',
+          label: 'ENERGY',
+          categories: ['ENERGY'],
+          detailed: [
+            'Renewable Energy',
+            'Nonrenewable Energy',
+            'Energy Resources',
+            'Energy & Environment',
+            'Power Generation',
+            'Energy Policy',
+          ],
+        },
+      ];
+
+      function renderTopics() {
+        if (!els.topicGrid) return;
+        els.topicGrid.innerHTML = TOPIC_GROUPS.map(group => `
+          <div class="topic-column">
+            <label class="topic-super">
+              <input type="checkbox" class="topic-super-checkbox" data-topic="${group.id}">
+              ${group.label}
+            </label>
+            <div class="topic-sublist">
+              ${group.detailed.map(topic => `
+                <label class="topic-option">
+                  <input type="checkbox" class="topic-detail-checkbox" data-topic="${group.id}" value="${topic}">
+                  ${topic}
+                </label>
+              `).join('')}
+            </div>
+          </div>
+        `).join('');
+      }
+
+      function selectedSuperTopics() {
+        return Array.from(document.querySelectorAll('.topic-super-checkbox:checked'))
+          .map(el => el.dataset.topic)
+          .filter(Boolean);
+      }
+
+      function selectedDetailedTopics() {
+        return Array.from(document.querySelectorAll('.topic-detail-checkbox:checked'))
+          .map(el => el.value)
+          .filter(Boolean);
+      }
+
+      function expandedCategories(selectedTopics) {
+        if (!selectedTopics.length) return [];
+        const lookup = new Map(TOPIC_GROUPS.map(group => [group.id, group.categories]));
+        return selectedTopics.flatMap(topic => lookup.get(topic) || []);
+      }
+
       
       function applyFilters(list, overrides = {}) {
         const level = overrides.level ?? els.level.value;
-        const category = overrides.category ?? els.category.value;
+        const categories = overrides.categories ?? expandedCategories(selectedSuperTopics());
+        const detailedCategories = overrides.detailedCategories ?? selectedDetailedTopics();
         const qaType = overrides.qaType ?? els.qaType.value;
         const bonus = overrides.bonus ?? els.bonus.value;
         const setName = (overrides.setName ?? els.setName.value).trim();
@@ -55,7 +237,11 @@
 
         return list.filter(q => {
           if (level !== 'ANY' && q.level !== level) return false;
-          if (category !== 'ANY' && normCat(q.category) !== category) return false;
+          if (categories.length && !categories.includes(normCat(q.category))) return false;
+          if (detailedCategories.length) {
+            const detailed = normCat(q.detailed_category || q.detailedCategory);
+            if (!detailedCategories.includes(detailed)) return false;
+          }
           if (qaType !== 'ANY' && q.type !== qaType) return false;
           if (bonus !== 'ANY' && String(!!q.bonus) !== bonus) return false;
           if (setName && q.set_name !== setName) return false;
@@ -78,7 +264,8 @@
         const cfg = {
           mode,
           level: els.level.value,
-          category: els.category.value,
+          categories: selectedSuperTopics(),
+          detailedCategories: selectedDetailedTopics(),
           qaType: els.qaType.value,
           bonus: els.bonus.value,
           count: Math.max(1, parseInt(els.count.value || '25', 10)),
@@ -137,7 +324,15 @@
         el.addEventListener('change', updateCounts);
         el.addEventListener('input', updateCounts);
       }
-      els.category.addEventListener('change', updateCounts);
+
+      renderTopics();
+      els.topicGrid?.addEventListener('change', updateCounts);
+      els.clearTopics?.addEventListener('click', () => {
+        document.querySelectorAll('.topic-super-checkbox, .topic-detail-checkbox').forEach(input => {
+          input.checked = false;
+        });
+        updateCounts();
+      });
 
       els.bankSelect.addEventListener('change', () => {
         loadBank();

--- a/docs/practice_home.html
+++ b/docs/practice_home.html
@@ -73,26 +73,6 @@
         </div>
 
         <div class="field">
-          <label for="category">Category</label>
-          <select id="category">
-            <option value="ANY">Any</option>
-            <option value="EARTH SCIENCE">Earth Science</option>
-            <option value="MATH">Math</option>
-            <option value="MATHEMATICS">Mathematics</option>
-            <option value="ASTRONOMY">Astronomy</option>
-            <option value="EARTH AND SPACE">Earth & Space</option>
-            <option value="EARTH AND SPACE SCIENCE">Earth & Space Science</option>
-            <option value="BIOLOGY">Biology</option>
-            <option value="LIFE SCIENCE">Life Science</option>
-            <option value="GENERAL SCIENCE">General Science</option>
-            <option value="CHEMISTRY">Chemistry</option>
-            <option value="PHYSICS">Physics</option>
-            <option value="PHYSICAL SCIENCE">Physical Science</option>
-            <option value="ENERGY">Energy</option>
-          </select>
-        </div>
-
-        <div class="field">
           <label for="qaType">Question Type</label>
           <select id="qaType">
             <option value="ANY">Both (SA + WXYZ)</option>
@@ -135,6 +115,17 @@
           <label for="roundName">Round name (optional)</label>
           <input id="roundName" placeholder="e.g., round10 (leave blank for any)" />
         </div>
+      </div>
+
+      <div class="topic-panel">
+        <div class="topic-panel-header">
+          <div>
+            <div class="topic-title">Topics (multi-select)</div>
+            <div class="mini">Pick one or more super topics and/or detailed subtopics.</div>
+          </div>
+          <button class="topic-clear" type="button" id="clearTopics">Clear all</button>
+        </div>
+        <div class="topic-grid" id="topicGrid" aria-live="polite"></div>
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Provide a richer Practice settings UI so users can pick multiple super-topics and detailed subtopics (stored as `detailed_category`) for runs. 
- Keep the previously-introduced desktop sidebar/layout behavior unchanged while adding the new topic UI.

### Description
- Added a topic panel UI (multi-column grid of super topics with detailed subtopic checkboxes and a clear-all button) to `docs/practice_home.html` and styling in `docs/css/practice_home.css`.
- Implemented topic rendering, multi-select handling, and count updates in `docs/js/practice_home.js` via a `TOPIC_GROUPS` structure, `renderTopics()`, and helpers `selectedSuperTopics()` / `selectedDetailedTopics()`; the run config now includes `categories` and `detailedCategories` when saved to `localStorage`.
- Extended the Practice engine (`docs/js/practice.js`) to accept `categories` and `detailedCategories` from the run config, expand selected super-topics into category names, and filter bank items by the chosen super/detailed topics (checking `detailed_category` fields when provided).
- Preserved existing desktop-nav/layout CSS changes so desktop-only offsets remain scoped to media queries.

### Testing
- Launched a local static server with `python -m http.server 8000` (served site successfully). — Success.
- Ran a headless Playwright script that opened `http://127.0.0.1:8000/practice_home.html` and captured a full-page screenshot saved to `artifacts/practice-topics.png`. — Success.
- Basic in-page assertions and live-count updates exercised by the browser run (console assertions present); no automated unit tests were added. — Observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f4f88f388323a2923a88469cde04)